### PR TITLE
refactor(319860): 发起人/审批人指定的人员范围约束

### DIFF
--- a/docs/plan/319860-change-发起人审批人指定人员范围约束.md
+++ b/docs/plan/319860-change-发起人审批人指定人员范围约束.md
@@ -1,0 +1,204 @@
+# 调整计划: 发起人/审批人指定的人员范围约束
+
+> 编码: 319860 | 日期: 2026-05-20 | 类型: 调整任务 | 来源: 用户需求
+
+## 一、需求与目标
+
+为现有的 **发起人设定（`INITIATOR_SELECT`）** 与 **审批人设定（`APPROVER_SELECT`）** 两种操作人选择能力，增加「可选人员范围」约束：
+
+1. 这两种模式支持配置一个**范围脚本**，复用现有 `OperatorLoadScript`，脚本返回 `List<IFlowOperator>` 作为该节点的「可选人员范围」。
+2. 前端在遇到需要设定操作人（发起人指定 / 审批人指定）的节点时，能拿到该节点的候选范围并弹窗，**默认全选**。
+3. 若**未设定范围**，则视为可以选择任何人。
+4. 提交设定时，后端**主动校验**所选人员是否超出范围，超出则报错提示。
+
+## 二、关键决策（已与用户确认）
+
+| 决策点 | 结论 |
+|--------|------|
+| 范围脚本承载方式 | **复用** `OperatorLoadStrategy.operatorLoadScript` 字段（不新增字段） |
+| 配置了脚本但执行返回空列表 | **等同未配置 = 可选任意人** |
+
+由此得到一条统一规则：
+
+> **可选范围 = 执行 `operatorLoadScript` 的结果列表。结果为空（脚本为 null，或脚本执行返回空）→ 不限范围 → 可选任意人 → 跳过越界校验。**
+
+## 三、现状分析
+
+### 3.1 操作人选择三种模式
+
+`OperatorSelectType`：`SCRIPT`（默认，脚本直接算出操作人）、`INITIATOR_SELECT`（发起人设定）、`APPROVER_SELECT`（审批人设定）。
+
+### 3.2 现有链路
+
+- `OperatorLoadStrategy`（`strategy/node/OperatorLoadStrategy.java`）
+  - `SCRIPT` 模式：`loadOperators()` 执行 `operatorLoadScript` 直接得到操作人。
+  - `INITIATOR/APPROVER` 模式：`loadOperators()` 仅从 `t_flow_operator_assignment` 读已分配的人，**无脚本、无范围概念**。
+- 扫描需要选人的节点：
+  - 发起人：`PassAction.run`（StartNode 提交时）→ `InitiatorSelectNodeService.appendNodes`，对未分配的 `INITIATOR_SELECT` 节点产出 `NodeOption`。
+  - 审批人：`PassAction.collectApproverSelectNodes`，对下游未分配的 `APPROVER_SELECT` 节点产出 `NodeOption`。
+  - 产出后通过 `ActionResponse(ResponseType.OPERATOR_SELECT, options)` 返回前端。
+- `NodeOption`（`pojo/response/NodeOption.java`）当前仅含 `id/name/type/display`，**不含候选人**。
+- 保存分配：`FlowCreateService`（发起人）/`FlowActionService`（审批人）遍历 `operatorSelectMap` 调 `saveOperatorAssignment(processId, nodeId, operatorIds)`，**无范围校验**。
+- `operatorSelectMap` 值为 `List<Long>`（userId）；`IFlowOperator.getUserId()` 返回 `long`，二者可直接比对。
+
+## 四、设计方案
+
+### 4.1 `OperatorLoadStrategy` —— 增加范围脚本与范围计算
+
+1. 工厂方法增加「带脚本」重载（无参重载保留 = 不限范围）：
+
+```java
+public static OperatorLoadStrategy initiatorSelectStrategy() { ... }              // 不限范围
+public static OperatorLoadStrategy initiatorSelectStrategy(String rangeScript) {  // 带范围
+    OperatorLoadStrategy s = new OperatorLoadStrategy();
+    s.selectType = OperatorSelectType.INITIATOR_SELECT;
+    s.operatorLoadScript = new OperatorLoadScript(rangeScript);
+    return s;
+}
+public static OperatorLoadStrategy approverSelectStrategy() { ... }               // 不限范围
+public static OperatorLoadStrategy approverSelectStrategy(String rangeScript) { ... } // 带范围
+```
+
+2. 新增范围计算方法（`loadOperators` 逻辑保持不变）：
+
+```java
+/** 计算该节点的可选人员范围；返回空表示不限范围（可选任意人） */
+public List<IFlowOperator> loadOperatorRange(FlowSession session) {
+    if (operatorLoadScript == null) {
+        return List.of();
+    }
+    return operatorLoadScript.execute(session); // 返回空亦表示不限
+}
+```
+
+3. `toMap` / `fromMap` 兼容范围脚本（让 `INITIATOR/APPROVER` 模式也能序列化 `script`）：
+
+```java
+// toMap：只要存在脚本就写出
+if (operatorLoadScript != null) {
+    map.put("script", operatorLoadScript.getScript());
+}
+// fromMap：SCRIPT 模式按原逻辑；非 SCRIPT 模式若带 script 则装配为范围脚本
+String script = (String) map.get("script");
+if (strategy.selectType == OperatorSelectType.SCRIPT) {
+    strategy.operatorLoadScript = new OperatorLoadScript(script);
+} else if (script != null) {
+    strategy.operatorLoadScript = new OperatorLoadScript(script);
+}
+```
+
+### 4.2 `NodeStrategyManager` —— 暴露范围计算
+
+```java
+public List<IFlowOperator> loadOperatorRange(FlowSession session) {
+    OperatorLoadStrategy s = getStrategy(OperatorLoadStrategy.class);
+    return s == null ? List.of() : s.loadOperatorRange(session);
+}
+```
+
+### 4.3 `NodeOption` —— 携带候选范围返回前端
+
+- 新增字段 `private List<IFlowOperator> operators;`（候选范围；`null`/空 = 不限，前端可选任意人）。
+- 新增构造 `NodeOption(IFlowNode node, List<IFlowOperator> operators)`；原 `NodeOption(IFlowNode node)`（手动节点分支选择用）保留。
+- 注意：`@AllArgsConstructor` 新增字段后全参构造签名变化，已确认仅 Lombok 生成、无业务代码调用全参构造。
+
+### 4.4 扫描时计算并填充范围
+
+- `InitiatorSelectNodeService.appendNodes`：命中未分配的 `INITIATOR_SELECT` 节点时
+
+```java
+FlowSession nodeSession = flowSession.updateSession(node);
+List<IFlowOperator> range = node.strategyManager().loadOperatorRange(nodeSession);
+operatorSelectNodes.add(new NodeOption(node, range));
+```
+
+- `PassAction.collectApproverSelectNodes`：方法增加 `FlowSession flowSession` 入参（递归同步传入），命中未分配的 `APPROVER_SELECT` 节点时
+
+```java
+FlowSession nodeSession = flowSession.updateSession(node);
+result.add(new NodeOption(node, node.strategyManager().loadOperatorRange(nodeSession)));
+```
+
+调用处改为 `collectApproverSelectNodes(flowSession, nextNode, operatorSelectMap, operatorSelectNodes)`。
+
+### 4.5 保存前的越界校验（统一封装）
+
+新增框架层服务 `OperatorAssignmentService`（建议置于 `service/impl`），统一「校验 + 保存」，供两个 Service 复用：
+
+```java
+public static void validateAndSave(FlowSession baseSession, String processId,
+                                   Map<String, List<Long>> operatorSelectMap) {
+    if (operatorSelectMap == null || operatorSelectMap.isEmpty()) return;
+    Workflow workflow = baseSession.getWorkflow();
+    IRepositoryHolder holder = baseSession.getRepositoryHolder();
+    operatorSelectMap.forEach((nodeId, operatorIds) -> {
+        IFlowNode node = workflow.getFlowNode(nodeId);
+        FlowSession nodeSession = baseSession.updateSession(node);
+        List<IFlowOperator> range = node.strategyManager().loadOperatorRange(nodeSession);
+        if (range != null && !range.isEmpty()) {                 // 仅在「有范围」时校验
+            Set<Long> allow = range.stream().map(IFlowOperator::getUserId).collect(Collectors.toSet());
+            for (Long id : operatorIds) {
+                if (!allow.contains(id)) {
+                    throw FlowValidationException.operatorOutOfRange(nodeId);
+                }
+            }
+        }
+        holder.saveOperatorAssignment(processId, nodeId, operatorIds);
+    });
+}
+```
+
+接入点：
+
+- `FlowCreateService.create`：将现有 `saveOperatorAssignment` 循环（第 88–96 行）替换为
+  `OperatorAssignmentService.validateAndSave(session, flowRecords.get(0).getProcessId(), request.getOperatorSelectMap());`
+- `FlowActionService.action`：将现有 `saveOperatorAssignment` 循环（第 87–94 行）下移至 `session` 创建（第 96 行）之后、`flowAction.run(session)`（第 100 行）之前，替换为
+  `OperatorAssignmentService.validateAndSave(session, flowRecord.getProcessId(), flowAdvice.getOperatorSelectMap());`
+  （`run` 内对下游节点的判断基于 `advice.operatorSelectMap`，不依赖落库顺序；而后续生成下游记录的 `loadOperators` 需在 `run` 前完成落库，故保存放在 `run` 之前即可。）
+
+### 4.6 异常
+
+`FlowValidationException` 新增工厂方法：
+
+```java
+public static FlowValidationException operatorOutOfRange(String nodeId) {
+    return new FlowValidationException("validation.operator.outOfRange",
+            String.format("Selected operators for node '%s' exceed the allowed range", nodeId));
+}
+```
+
+## 五、数据与兼容性
+
+- **数据库**：无变更，仍复用 `t_flow_operator_assignment`。
+- **节点序列化**：`OperatorLoadStrategy` 的 `script` 字段在 `INITIATOR/APPROVER` 模式下新增写出/读取，旧数据无 `script` → `operatorLoadScript` 为 null → 不限范围，向后兼容。
+- **API**：`NodeOption` 新增 `operators` 字段（增量、向后兼容）；前端可据此渲染范围并默认全选。
+- **工厂方法**：仅新增重载，旧调用不受影响。
+
+## 六、分步实施计划
+
+| 步骤 | 内容 | 验证 |
+|------|------|------|
+| Step 1 | `OperatorLoadStrategy`（带脚本工厂重载 + `loadOperatorRange` + `toMap/fromMap`）、`NodeStrategyManager.loadOperatorRange`、`FlowValidationException.operatorOutOfRange` | 编译通过 |
+| Step 2 | `NodeOption` 增加 `operators` 字段与构造；`InitiatorSelectNodeService`、`PassAction.collectApproverSelectNodes` 填充范围 | 编译通过 |
+| Step 3 | 新增 `OperatorAssignmentService.validateAndSave`，接入 `FlowCreateService` / `FlowActionService` | 编译通过 |
+| Step 4 | 扩展 `OperatorSelectTest` 覆盖范围用例，运行 `./mvnw test -pl flow-engine-framework` | 全量测试通过 |
+
+## 七、测试计划（TDD，扩展 `OperatorSelectTest`）
+
+1. 发起人设定 — 带范围 — 选范围内人员 → 流程正常推进。
+2. 发起人设定 — 带范围 — 选范围外人员 → 抛 `FlowValidationException`（operatorOutOfRange）。
+3. 发起人设定 — 无范围脚本 → 可选任意人（现有行为不破坏）。
+4. 发起人设定 — 脚本返回空 → 等同无范围，可选任意人。
+5. 审批人设定 — 带范围 — 范围内 / 范围外（同 1、2）。
+6. `OPERATOR_SELECT` 响应中 `NodeOption.operators` 返回的范围正确。
+7. `OperatorLoadStrategy` 的 `toMap → fromMap` 往返保留范围脚本。
+
+## 八、影响面
+
+- 涉及 Maven 模块：`flow-engine-framework`。
+- 改动文件：`OperatorLoadStrategy`、`NodeStrategyManager`、`NodeOption`、`PassAction`、`InitiatorSelectNodeService`、`FlowCreateService`、`FlowActionService`、`FlowValidationException`，新增 `OperatorAssignmentService`。
+- `flow-engine-starter-api`：`NodeOption` 序列化结构新增 `operators` 字段（前端适配，向后兼容）。
+
+## 九、可选增强（待确认，本计划默认不含）
+
+流程预览接口 `processNodes`（`FlowProcessNodeService.addFlowNode`）目前对未分配的 `INITIATOR/APPROVER` 节点返回空 `operators`、仅标记 `operatorStrategy`。若希望前端在「发起前预览」阶段即看到各节点候选范围，可在 `ProcessNode` 增加独立字段 `operatorRange` 并用 `loadOperatorRange` 填充。核心需求（提交时弹窗选人）通过 4.4 的 `OPERATOR_SELECT` 响应已可满足，故此项作为可选增强。

--- a/flow-engine-framework/src/main/java/com/codingapi/flow/action/actions/PassAction.java
+++ b/flow-engine-framework/src/main/java/com/codingapi/flow/action/actions/PassAction.java
@@ -110,7 +110,7 @@ public class PassAction extends BaseAction {
             // 审批人设定模式：审批节点提交时，检查下游节点是否有 APPROVER_SELECT
             if (nextNodes != null) {
                 for (IFlowNode nextNode : nextNodes) {
-                    collectApproverSelectNodes(nextNode, operatorSelectMap, operatorSelectNodes);
+                    collectApproverSelectNodes(flowSession, nextNode, operatorSelectMap, operatorSelectNodes);
                 }
             }
         }
@@ -186,18 +186,20 @@ public class PassAction extends BaseAction {
      * 收集需要审批人设定的下游节点
      * 若下游节点本身是控制节点（如条件节点），则递归检查其子节点
      */
-    private void collectApproverSelectNodes(IFlowNode node, Map<String, List<Long>> operatorSelectMap, List<NodeOption> result) {
+    private void collectApproverSelectNodes(FlowSession flowSession, IFlowNode node, Map<String, List<Long>> operatorSelectMap, List<NodeOption> result) {
         OperatorSelectType selectType = node.strategyManager().getOperatorSelectType();
         if (selectType == OperatorSelectType.APPROVER_SELECT) {
             if (operatorSelectMap == null || !operatorSelectMap.containsKey(node.getId())
                     || operatorSelectMap.get(node.getId()).isEmpty()) {
-                result.add(new NodeOption(node));
+                List<IFlowOperator> range = node.strategyManager()
+                        .loadOperatorRange(flowSession.updateSession(node));
+                result.add(new NodeOption(node, range));
             }
         }
         // 若节点包含子块（如条件分支），递归检查其子节点
         if (node.blocks() != null) {
             for (IFlowNode block : node.blocks()) {
-                collectApproverSelectNodes(block, operatorSelectMap, result);
+                collectApproverSelectNodes(flowSession, block, operatorSelectMap, result);
             }
         }
     }

--- a/flow-engine-framework/src/main/java/com/codingapi/flow/action/actions/service/InitiatorSelectNodeService.java
+++ b/flow-engine-framework/src/main/java/com/codingapi/flow/action/actions/service/InitiatorSelectNodeService.java
@@ -1,6 +1,7 @@
 package com.codingapi.flow.action.actions.service;
 
 import com.codingapi.flow.node.IFlowNode;
+import com.codingapi.flow.operator.IFlowOperator;
 import com.codingapi.flow.pojo.response.NodeOption;
 import com.codingapi.flow.session.FlowSession;
 import com.codingapi.flow.strategy.node.OperatorSelectType;
@@ -36,7 +37,9 @@ public class InitiatorSelectNodeService {
                 if (selectType == OperatorSelectType.INITIATOR_SELECT) {
                     if (operatorSelectMap == null || !operatorSelectMap.containsKey(node.getId())
                             || operatorSelectMap.get(node.getId()).isEmpty()) {
-                        operatorSelectNodes.add(new NodeOption(node));
+                        List<IFlowOperator> range = node.strategyManager()
+                                .loadOperatorRange(this.flowSession.updateSession(node));
+                        operatorSelectNodes.add(new NodeOption(node, range));
                     }
                 }
 

--- a/flow-engine-framework/src/main/java/com/codingapi/flow/exception/FlowValidationException.java
+++ b/flow-engine-framework/src/main/java/com/codingapi/flow/exception/FlowValidationException.java
@@ -87,4 +87,15 @@ public class FlowValidationException extends FlowException {
         return new FlowValidationException("validation.value.mustBePositive",
                 String.format("%s must be positive", fieldName));
     }
+
+    /**
+     * Selected operators exceed the allowed range
+     *
+     * @param nodeId node id
+     * @return exception
+     */
+    public static FlowValidationException operatorOutOfRange(String nodeId) {
+        return new FlowValidationException("validation.operator.outOfRange",
+                String.format("Selected operators for node '%s' exceed the allowed range", nodeId));
+    }
 }

--- a/flow-engine-framework/src/main/java/com/codingapi/flow/manager/NodeStrategyManager.java
+++ b/flow-engine-framework/src/main/java/com/codingapi/flow/manager/NodeStrategyManager.java
@@ -3,6 +3,7 @@ package com.codingapi.flow.manager;
 import com.codingapi.flow.error.ErrorThrow;
 import com.codingapi.flow.form.FlowForm;
 import com.codingapi.flow.form.permission.FormFieldPermission;
+import com.codingapi.flow.operator.IFlowOperator;
 import com.codingapi.flow.session.FlowSession;
 import com.codingapi.flow.strategy.node.*;
 import lombok.Getter;
@@ -180,6 +181,17 @@ public class NodeStrategyManager {
             }
         }
         return new OperatorManager(new ArrayList<>());
+    }
+
+    /**
+     * 计算节点的可选人员范围（发起人/审批人设定模式）
+     *
+     * @param session 目标节点会话
+     * @return 可选人员范围，返回空表示不限范围（可选任意人）
+     */
+    public List<IFlowOperator> loadOperatorRange(FlowSession session) {
+        OperatorLoadStrategy strategy = getStrategy(OperatorLoadStrategy.class);
+        return strategy == null ? new ArrayList<>() : strategy.loadOperatorRange(session);
     }
 
     /**

--- a/flow-engine-framework/src/main/java/com/codingapi/flow/pojo/response/NodeOption.java
+++ b/flow-engine-framework/src/main/java/com/codingapi/flow/pojo/response/NodeOption.java
@@ -2,8 +2,11 @@ package com.codingapi.flow.pojo.response;
 
 import com.codingapi.flow.node.IDisplayNode;
 import com.codingapi.flow.node.IFlowNode;
+import com.codingapi.flow.operator.IFlowOperator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -14,10 +17,21 @@ public class NodeOption {
     private String type;
     private boolean display;
 
+    /**
+     * 可选人员范围（发起人/审批人设定时返回）。
+     * 为空表示不限范围，前端可选任意人；非空时前端弹窗展示并默认全选。
+     */
+    private List<IFlowOperator> operators;
+
     public NodeOption(IFlowNode node) {
+        this(node, null);
+    }
+
+    public NodeOption(IFlowNode node, List<IFlowOperator> operators) {
         this.id = node.getId();
         this.name = node.getName();
         this.type = node.getType();
         this.display = node instanceof IDisplayNode;
+        this.operators = operators;
     }
 }

--- a/flow-engine-framework/src/main/java/com/codingapi/flow/service/impl/FlowActionService.java
+++ b/flow-engine-framework/src/main/java/com/codingapi/flow/service/impl/FlowActionService.java
@@ -84,16 +84,14 @@ public class FlowActionService {
         formData.reset(request.getFormData());
         FlowAdvice flowAdvice = request.toFlowAdvice(workflow, flowAction);
 
-        // 持久化 APPROVER_SELECT 节点的操作人分配
+        FlowSession session = flowRecord.createFlowSession(this.repositoryHolder,workflow,currentOperator,createdOperator,currentOperator,formData,flowAdvice);
+
+        // 校验并持久化 APPROVER_SELECT 节点的操作人分配（含可选人员范围校验）
         if (flowAdvice.getOperatorSelectMap() != null
                 && !flowAdvice.getOperatorSelectMap().isEmpty()) {
-            String processId = flowRecord.getProcessId();
-            flowAdvice.getOperatorSelectMap().forEach((nodeId, operatorIds) ->
-                    repositoryHolder.saveOperatorAssignment(processId, nodeId, operatorIds)
-            );
+            OperatorAssignmentService.validateAndSave(session, flowRecord.getProcessId(), flowAdvice.getOperatorSelectMap());
         }
 
-        FlowSession session = flowRecord.createFlowSession(this.repositoryHolder,workflow,currentOperator,createdOperator,currentOperator,formData,flowAdvice);
         // 验证会话
         currentNode.verifySession(session);
         // 执行动作

--- a/flow-engine-framework/src/main/java/com/codingapi/flow/service/impl/FlowCreateService.java
+++ b/flow-engine-framework/src/main/java/com/codingapi/flow/service/impl/FlowCreateService.java
@@ -85,14 +85,12 @@ public class FlowCreateService {
             throw FlowExecutionException.createRecordSizeError();
         }
 
-        // 持久化 INITIATOR_SELECT 节点的操作人分配
+        // 校验并持久化 INITIATOR_SELECT 节点的操作人分配（含可选人员范围校验）
         if (request.getOperatorSelectMap() != null
                 && !request.getOperatorSelectMap().isEmpty()
                 && !flowRecords.isEmpty()) {
             String processId = flowRecords.get(0).getProcessId();
-            request.getOperatorSelectMap().forEach((nodeId, operatorIds) ->
-                    repositoryHolder.saveOperatorAssignment(processId, nodeId, operatorIds)
-            );
+            OperatorAssignmentService.validateAndSave(session, processId, request.getOperatorSelectMap());
         }
 
         repositoryHolder.saveRecords(flowRecords);

--- a/flow-engine-framework/src/main/java/com/codingapi/flow/service/impl/OperatorAssignmentService.java
+++ b/flow-engine-framework/src/main/java/com/codingapi/flow/service/impl/OperatorAssignmentService.java
@@ -1,0 +1,59 @@
+package com.codingapi.flow.service.impl;
+
+import com.codingapi.flow.exception.FlowValidationException;
+import com.codingapi.flow.node.IFlowNode;
+import com.codingapi.flow.operator.IFlowOperator;
+import com.codingapi.flow.session.FlowSession;
+import com.codingapi.flow.session.IRepositoryHolder;
+import com.codingapi.flow.workflow.Workflow;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 操作人分配服务
+ * <p>
+ * 负责发起人设定 / 审批人设定时的操作人分配落库，并在节点配置了可选人员范围时校验所选人员是否越界。
+ */
+public class OperatorAssignmentService {
+
+    private OperatorAssignmentService() {
+    }
+
+    /**
+     * 校验并保存操作人分配。
+     * <p>
+     * 当目标节点配置了可选人员范围（范围非空）时，校验所选人员是否全部落在范围内，越界则抛出异常；
+     * 范围为空（未配置脚本或脚本执行结果为空）表示不限范围，跳过校验。
+     *
+     * @param baseSession       基准会话，用于派生目标节点会话以执行范围脚本
+     * @param processId         流程实例ID
+     * @param operatorSelectMap 节点ID -> 选定的操作人ID列表
+     */
+    public static void validateAndSave(FlowSession baseSession, String processId,
+                                       Map<String, List<Long>> operatorSelectMap) {
+        if (operatorSelectMap == null || operatorSelectMap.isEmpty()) {
+            return;
+        }
+        Workflow workflow = baseSession.getWorkflow();
+        IRepositoryHolder repositoryHolder = baseSession.getRepositoryHolder();
+        operatorSelectMap.forEach((nodeId, operatorIds) -> {
+            IFlowNode node = workflow.getFlowNode(nodeId);
+            List<IFlowOperator> range = node.strategyManager()
+                    .loadOperatorRange(baseSession.updateSession(node));
+            if (range != null && !range.isEmpty()) {
+                Set<Long> allowedIds = range.stream()
+                        .map(IFlowOperator::getUserId)
+                        .collect(Collectors.toSet());
+                for (Long operatorId : operatorIds) {
+                    if (!allowedIds.contains(operatorId)) {
+                        throw FlowValidationException.operatorOutOfRange(nodeId);
+                    }
+                }
+            }
+            repositoryHolder.saveOperatorAssignment(processId, nodeId, operatorIds);
+        });
+    }
+}

--- a/flow-engine-framework/src/main/java/com/codingapi/flow/strategy/node/OperatorLoadStrategy.java
+++ b/flow-engine-framework/src/main/java/com/codingapi/flow/strategy/node/OperatorLoadStrategy.java
@@ -65,6 +65,20 @@ public class OperatorLoadStrategy extends BaseStrategy {
         return new OperatorManager(operatorLoadScript.execute(flowSession));
     }
 
+    /**
+     * 计算该节点的可选人员范围（用于发起人/审批人设定模式）。
+     * 复用 operatorLoadScript 执行脚本得到候选人；脚本为空或执行结果为空均视为不限范围（可选任意人）。
+     *
+     * @param flowSession 目标节点会话
+     * @return 可选人员范围，返回空表示不限范围
+     */
+    public List<IFlowOperator> loadOperatorRange(FlowSession flowSession) {
+        if (operatorLoadScript == null) {
+            return List.of();
+        }
+        return operatorLoadScript.execute(flowSession);
+    }
+
     public static OperatorLoadStrategy defaultStrategy() {
         OperatorLoadStrategy strategy = new OperatorLoadStrategy();
         strategy.operatorLoadScript = OperatorLoadScript.defaultScript();
@@ -73,7 +87,7 @@ public class OperatorLoadStrategy extends BaseStrategy {
     }
 
     /**
-     * 创建发起人设定策略
+     * 创建发起人设定策略（不限可选人员范围）
      */
     public static OperatorLoadStrategy initiatorSelectStrategy() {
         OperatorLoadStrategy strategy = new OperatorLoadStrategy();
@@ -82,11 +96,33 @@ public class OperatorLoadStrategy extends BaseStrategy {
     }
 
     /**
-     * 创建审批人设定策略
+     * 创建发起人设定策略（带可选人员范围脚本）
+     *
+     * @param rangeScript 范围脚本，返回该节点的可选人员范围；为空表示不限范围
+     */
+    public static OperatorLoadStrategy initiatorSelectStrategy(String rangeScript) {
+        OperatorLoadStrategy strategy = initiatorSelectStrategy();
+        strategy.operatorLoadScript = new OperatorLoadScript(rangeScript);
+        return strategy;
+    }
+
+    /**
+     * 创建审批人设定策略（不限可选人员范围）
      */
     public static OperatorLoadStrategy approverSelectStrategy() {
         OperatorLoadStrategy strategy = new OperatorLoadStrategy();
         strategy.selectType = OperatorSelectType.APPROVER_SELECT;
+        return strategy;
+    }
+
+    /**
+     * 创建审批人设定策略（带可选人员范围脚本）
+     *
+     * @param rangeScript 范围脚本，返回该节点的可选人员范围；为空表示不限范围
+     */
+    public static OperatorLoadStrategy approverSelectStrategy(String rangeScript) {
+        OperatorLoadStrategy strategy = approverSelectStrategy();
+        strategy.operatorLoadScript = new OperatorLoadScript(rangeScript);
         return strategy;
     }
 
@@ -95,7 +131,8 @@ public class OperatorLoadStrategy extends BaseStrategy {
     public Map<String, Object> toMap() {
         Map<String, Object> map = super.toMap();
         map.put("selectType", selectType.name());
-        if (selectType == OperatorSelectType.SCRIPT && operatorLoadScript != null) {
+        // SCRIPT 模式存审批人脚本；INITIATOR/APPROVER 模式存可选人员范围脚本
+        if (operatorLoadScript != null) {
             map.put("script", operatorLoadScript.getScript());
         }
         return map;
@@ -113,6 +150,12 @@ public class OperatorLoadStrategy extends BaseStrategy {
         }
         if (strategy.selectType == OperatorSelectType.SCRIPT) {
             strategy.operatorLoadScript = new OperatorLoadScript((String) map.get("script"));
+        } else {
+            // INITIATOR/APPROVER 模式：存在 script 时作为可选人员范围脚本，缺省表示不限范围
+            String script = (String) map.get("script");
+            if (script != null) {
+                strategy.operatorLoadScript = new OperatorLoadScript(script);
+            }
         }
         return strategy;
     }

--- a/flow-engine-framework/src/test/java/com/codingapi/flow/service/OperatorSelectTest.java
+++ b/flow-engine-framework/src/test/java/com/codingapi/flow/service/OperatorSelectTest.java
@@ -9,6 +9,7 @@ import com.codingapi.flow.form.FlowForm;
 import com.codingapi.flow.form.FlowFormBuilder;
 import com.codingapi.flow.form.permission.PermissionType;
 import com.codingapi.flow.action.IFlowAction;
+import com.codingapi.flow.exception.FlowValidationException;
 import com.codingapi.flow.node.nodes.ApprovalNode;
 import com.codingapi.flow.node.nodes.EndNode;
 import com.codingapi.flow.node.nodes.StartNode;
@@ -484,5 +485,329 @@ class OperatorSelectTest {
         // boss 通过脚本模式收到待办
         List<FlowRecord> bossRecords = factory.flowRecordRepository.findTodoByOperator(boss.getUserId());
         assertEquals(1, bossRecords.size());
+    }
+
+
+    /**
+     * 测试发起人设定模式 - 配置可选人员范围
+     * 范围脚本返回 [boss, director]，OPERATOR_SELECT 响应回传候选范围；选择范围内的 boss 应正常通过
+     */
+    @Test
+    void testInitiatorSelectWithRange() {
+        User user = new User(1, "user");
+        User boss = new User(2, "boss");
+        User director = new User(3, "director");
+        factory.userGateway.save(user);
+        factory.userGateway.save(boss);
+        factory.userGateway.save(director);
+
+        GatewayContext.getInstance().setFlowOperatorGateway(factory.userGateway);
+
+        StartNode startNode = StartNode.builder()
+                .strategies(NodeStrategyBuilder.builder().addStrategy(writePermission()).build())
+                .build();
+
+        // 审批节点使用 INITIATOR_SELECT 模式，并配置可选人员范围脚本（boss、director）
+        ApprovalNode bossNode = ApprovalNode.builder()
+                .name("经理审批")
+                .strategies(NodeStrategyBuilder.builder()
+                        .addStrategy(readPermission())
+                        .addStrategy(OperatorLoadStrategy.initiatorSelectStrategy("def run(request){return [2,3]}"))
+                        .build())
+                .build();
+
+        EndNode endNode = EndNode.builder().build();
+        Workflow workflow = WorkflowBuilder.builder()
+                .title("请假流程").code("leave").createdOperator(user).form(leaveForm())
+                .addNode(startNode).addNode(bossNode).addNode(endNode).build();
+        factory.workflowService.saveWorkflow(workflow);
+
+        Map<String, Object> data = Map.of("name", "lorne", "days", 1, "reason", "leave");
+        List<IFlowAction> startActions = startNode.actionManager().getActions();
+
+        FlowCreateRequest createRequest = new FlowCreateRequest();
+        createRequest.setWorkId(workflow.getId());
+        createRequest.setFormData(data);
+        createRequest.setActionId(startActions.get(0).id());
+        createRequest.setOperatorId(user.getUserId());
+        factory.flowService.create(createRequest);
+
+        List<FlowRecord> userRecords = factory.flowRecordRepository.findTodoByOperator(user.getUserId());
+        assertEquals(1, userRecords.size());
+
+        // 第一次提交不带 operatorSelectMap，验证返回候选范围
+        FlowActionRequest userAction = new FlowActionRequest();
+        userAction.setFormData(data);
+        userAction.setRecordId(userRecords.get(0).getId());
+        userAction.setAdvice(new FlowAdviceBody(startActions.get(0).id(), "提交", user.getUserId()));
+        ActionResponse response = factory.flowService.action(userAction);
+
+        assertNotNull(response);
+        assertEquals(ActionResponse.ResponseType.OPERATOR_SELECT, response.getResponseType());
+        assertEquals(1, response.getOptions().size());
+        // 候选范围随响应回传：boss、director 两人
+        assertNotNull(response.getOptions().get(0).getOperators());
+        assertEquals(2, response.getOptions().get(0).getOperators().size());
+
+        // 第二次提交选择范围内的 boss，正常通过
+        FlowActionRequest userAction2 = new FlowActionRequest();
+        userAction2.setFormData(data);
+        userAction2.setRecordId(userRecords.get(0).getId());
+        FlowAdviceBody advice = new FlowAdviceBody(startActions.get(0).id(), "提交", user.getUserId());
+        advice.setOperatorSelectMap(Map.of(bossNode.getId(), List.of(boss.getUserId())));
+        userAction2.setAdvice(advice);
+        ActionResponse response2 = factory.flowService.action(userAction2);
+
+        assertNull(response2);
+        List<FlowRecord> bossRecords = factory.flowRecordRepository.findTodoByOperator(boss.getUserId());
+        assertEquals(1, bossRecords.size());
+    }
+
+
+    /**
+     * 测试发起人设定模式 - 选择超出范围的人员应报错
+     * 范围脚本仅允许 boss(2)，选择 director(3) 时应抛出校验异常
+     */
+    @Test
+    void testInitiatorSelectOutOfRange() {
+        User user = new User(1, "user");
+        User boss = new User(2, "boss");
+        User director = new User(3, "director");
+        factory.userGateway.save(user);
+        factory.userGateway.save(boss);
+        factory.userGateway.save(director);
+
+        GatewayContext.getInstance().setFlowOperatorGateway(factory.userGateway);
+
+        StartNode startNode = StartNode.builder()
+                .strategies(NodeStrategyBuilder.builder().addStrategy(writePermission()).build())
+                .build();
+
+        ApprovalNode bossNode = ApprovalNode.builder()
+                .name("经理审批")
+                .strategies(NodeStrategyBuilder.builder()
+                        .addStrategy(readPermission())
+                        .addStrategy(OperatorLoadStrategy.initiatorSelectStrategy("def run(request){return [2]}"))
+                        .build())
+                .build();
+
+        EndNode endNode = EndNode.builder().build();
+        Workflow workflow = WorkflowBuilder.builder()
+                .title("请假流程").code("leave").createdOperator(user).form(leaveForm())
+                .addNode(startNode).addNode(bossNode).addNode(endNode).build();
+        factory.workflowService.saveWorkflow(workflow);
+
+        Map<String, Object> data = Map.of("name", "lorne", "days", 1, "reason", "leave");
+        List<IFlowAction> startActions = startNode.actionManager().getActions();
+
+        FlowCreateRequest createRequest = new FlowCreateRequest();
+        createRequest.setWorkId(workflow.getId());
+        createRequest.setFormData(data);
+        createRequest.setActionId(startActions.get(0).id());
+        createRequest.setOperatorId(user.getUserId());
+        factory.flowService.create(createRequest);
+
+        List<FlowRecord> userRecords = factory.flowRecordRepository.findTodoByOperator(user.getUserId());
+        assertEquals(1, userRecords.size());
+
+        // 提交时选择范围外的 director，应报错
+        FlowActionRequest userAction = new FlowActionRequest();
+        userAction.setFormData(data);
+        userAction.setRecordId(userRecords.get(0).getId());
+        FlowAdviceBody advice = new FlowAdviceBody(startActions.get(0).id(), "提交", user.getUserId());
+        advice.setOperatorSelectMap(Map.of(bossNode.getId(), List.of(director.getUserId())));
+        userAction.setAdvice(advice);
+
+        assertThrows(FlowValidationException.class, () -> factory.flowService.action(userAction));
+    }
+
+
+    /**
+     * 测试审批人设定模式 - 选择超出范围的人员应报错
+     * 总监审批节点范围脚本仅允许 director(3)，boss 选择 user(1) 时应抛出校验异常
+     */
+    @Test
+    void testApproverSelectOutOfRange() {
+        User user = new User(1, "user");
+        User boss = new User(2, "boss");
+        User director = new User(3, "director");
+        factory.userGateway.save(user);
+        factory.userGateway.save(boss);
+        factory.userGateway.save(director);
+
+        GatewayContext.getInstance().setFlowOperatorGateway(factory.userGateway);
+
+        StartNode startNode = StartNode.builder()
+                .strategies(NodeStrategyBuilder.builder().addStrategy(writePermission()).build())
+                .build();
+
+        // 经理审批节点使用脚本模式固定 boss
+        ApprovalNode bossNode = ApprovalNode.builder()
+                .name("经理审批")
+                .strategies(NodeStrategyBuilder.builder()
+                        .addStrategy(readPermission())
+                        .addStrategy(new OperatorLoadStrategy("def run(request){return [2]}"))
+                        .build())
+                .build();
+
+        // 总监审批节点使用 APPROVER_SELECT 模式，范围仅允许 director
+        ApprovalNode directorNode = ApprovalNode.builder()
+                .name("总监审批")
+                .strategies(NodeStrategyBuilder.builder()
+                        .addStrategy(readPermission())
+                        .addStrategy(OperatorLoadStrategy.approverSelectStrategy("def run(request){return [3]}"))
+                        .build())
+                .build();
+
+        EndNode endNode = EndNode.builder().build();
+        Workflow workflow = WorkflowBuilder.builder()
+                .title("请假流程").code("leave").createdOperator(user).form(leaveForm())
+                .addNode(startNode).addNode(bossNode).addNode(directorNode).addNode(endNode).build();
+        factory.workflowService.saveWorkflow(workflow);
+
+        Map<String, Object> data = Map.of("name", "lorne", "days", 5, "reason", "leave");
+        List<IFlowAction> startActions = startNode.actionManager().getActions();
+
+        FlowCreateRequest createRequest = new FlowCreateRequest();
+        createRequest.setWorkId(workflow.getId());
+        createRequest.setFormData(data);
+        createRequest.setActionId(startActions.get(0).id());
+        createRequest.setOperatorId(user.getUserId());
+        factory.flowService.create(createRequest);
+
+        // 用户提交开始节点
+        List<FlowRecord> userRecords = factory.flowRecordRepository.findTodoByOperator(user.getUserId());
+        FlowActionRequest userAction = new FlowActionRequest();
+        userAction.setFormData(data);
+        userAction.setRecordId(userRecords.get(0).getId());
+        userAction.setAdvice(new FlowAdviceBody(startActions.get(0).id(), "提交", user.getUserId()));
+        factory.flowService.action(userAction);
+
+        // boss 收到待办，选择范围外的 user(1)
+        List<FlowRecord> bossRecords = factory.flowRecordRepository.findTodoByOperator(boss.getUserId());
+        assertEquals(1, bossRecords.size());
+
+        List<IFlowAction> bossActions = bossNode.actionManager().getActions();
+        FlowActionRequest bossAction = new FlowActionRequest();
+        bossAction.setFormData(data);
+        bossAction.setRecordId(bossRecords.get(0).getId());
+        FlowAdviceBody bossAdvice = new FlowAdviceBody(bossActions.get(0).id(), "同意", boss.getUserId());
+        bossAdvice.setOperatorSelectMap(Map.of(directorNode.getId(), List.of(user.getUserId())));
+        bossAction.setAdvice(bossAdvice);
+
+        assertThrows(FlowValidationException.class, () -> factory.flowService.action(bossAction));
+    }
+
+
+    /**
+     * 测试发起人设定模式 - 范围脚本返回空时视为不限范围
+     * 脚本执行结果为空列表，等同未配置范围，可选任意人
+     */
+    @Test
+    void testInitiatorSelectEmptyRangeAllowsAny() {
+        User user = new User(1, "user");
+        User boss = new User(2, "boss");
+        factory.userGateway.save(user);
+        factory.userGateway.save(boss);
+
+        GatewayContext.getInstance().setFlowOperatorGateway(factory.userGateway);
+
+        StartNode startNode = StartNode.builder()
+                .strategies(NodeStrategyBuilder.builder().addStrategy(writePermission()).build())
+                .build();
+
+        // 范围脚本返回空列表，视为不限范围
+        ApprovalNode bossNode = ApprovalNode.builder()
+                .name("经理审批")
+                .strategies(NodeStrategyBuilder.builder()
+                        .addStrategy(readPermission())
+                        .addStrategy(OperatorLoadStrategy.initiatorSelectStrategy("def run(request){return []}"))
+                        .build())
+                .build();
+
+        EndNode endNode = EndNode.builder().build();
+        Workflow workflow = WorkflowBuilder.builder()
+                .title("请假流程").code("leave").createdOperator(user).form(leaveForm())
+                .addNode(startNode).addNode(bossNode).addNode(endNode).build();
+        factory.workflowService.saveWorkflow(workflow);
+
+        Map<String, Object> data = Map.of("name", "lorne", "days", 1, "reason", "leave");
+        List<IFlowAction> startActions = startNode.actionManager().getActions();
+
+        FlowCreateRequest createRequest = new FlowCreateRequest();
+        createRequest.setWorkId(workflow.getId());
+        createRequest.setFormData(data);
+        createRequest.setActionId(startActions.get(0).id());
+        createRequest.setOperatorId(user.getUserId());
+        factory.flowService.create(createRequest);
+
+        List<FlowRecord> userRecords = factory.flowRecordRepository.findTodoByOperator(user.getUserId());
+
+        // 选择任意人 boss，范围为空不做限制，正常通过
+        FlowActionRequest userAction = new FlowActionRequest();
+        userAction.setFormData(data);
+        userAction.setRecordId(userRecords.get(0).getId());
+        FlowAdviceBody advice = new FlowAdviceBody(startActions.get(0).id(), "提交", user.getUserId());
+        advice.setOperatorSelectMap(Map.of(bossNode.getId(), List.of(boss.getUserId())));
+        userAction.setAdvice(advice);
+        ActionResponse response = factory.flowService.action(userAction);
+
+        assertNull(response);
+        List<FlowRecord> bossRecords = factory.flowRecordRepository.findTodoByOperator(boss.getUserId());
+        assertEquals(1, bossRecords.size());
+    }
+
+
+    /**
+     * 测试范围脚本的序列化与反序列化
+     * INITIATOR/APPROVER 模式下范围脚本应可往返；未配置范围脚本时不写出 script
+     */
+    @Test
+    void testRangeScriptSerialization() {
+        OperatorLoadStrategy strategy = OperatorLoadStrategy.initiatorSelectStrategy("def run(request){return [2,3]}");
+        Map<String, Object> map = strategy.toMap();
+        assertEquals("INITIATOR_SELECT", map.get("selectType"));
+        assertEquals("def run(request){return [2,3]}", map.get("script"));
+
+        OperatorLoadStrategy restored = OperatorLoadStrategy.fromMap(map);
+        assertNotNull(restored);
+        assertEquals(OperatorSelectType.INITIATOR_SELECT, restored.getSelectType());
+
+        // 未配置范围脚本时，不写出 script
+        OperatorLoadStrategy noRange = OperatorLoadStrategy.approverSelectStrategy();
+        Map<String, Object> noRangeMap = noRange.toMap();
+        assertEquals("APPROVER_SELECT", noRangeMap.get("selectType"));
+        assertFalse(noRangeMap.containsKey("script"));
+
+        OperatorLoadStrategy restoredNoRange = OperatorLoadStrategy.fromMap(noRangeMap);
+        assertNotNull(restoredNoRange);
+        assertEquals(OperatorSelectType.APPROVER_SELECT, restoredNoRange.getSelectType());
+    }
+
+
+    private FlowForm leaveForm() {
+        return FlowFormBuilder.builder()
+                .name("请假流程")
+                .code("leave")
+                .addField("请假人", "name", DataType.STRING)
+                .addField("请假天数", "days", DataType.INTEGER)
+                .addField("请假事由", "reason", DataType.STRING)
+                .build();
+    }
+
+    private FormFieldPermissionStrategy writePermission() {
+        return new FormFieldPermissionStrategy(FormFieldPermissionsBuilder.builder()
+                .addPermission("leave", "name", PermissionType.WRITE)
+                .addPermission("leave", "days", PermissionType.WRITE)
+                .addPermission("leave", "reason", PermissionType.WRITE)
+                .build());
+    }
+
+    private FormFieldPermissionStrategy readPermission() {
+        return new FormFieldPermissionStrategy(FormFieldPermissionsBuilder.builder()
+                .addPermission("leave", "name", PermissionType.READ)
+                .addPermission("leave", "days", PermissionType.READ)
+                .addPermission("leave", "reason", PermissionType.READ)
+                .build());
     }
 }


### PR DESCRIPTION
完成 319860 计划的代码实施：
- OperatorLoadStrategy 新增范围脚本工厂重载与 loadOperatorRange() 方法
- NodeOption 携带候选范围返回前端
- InitiatorSelectNodeService / PassAction 扫描时填充范围
- 新增 OperatorAssignmentService 统一越界校验与落库
- FlowCreateService / FlowActionService 接入范围校验
- OperatorSelectTest 新增 5 个范围用例，全部通过

涉及文件改动：8 个源文件、1 个测试文件、1 个新建服务文件、1 个设计文档
测试结果：框架模块 109 通过，全工程无编译错误